### PR TITLE
Regex syntax fixes

### DIFF
--- a/regex_builder/quantifiers.py
+++ b/regex_builder/quantifiers.py
@@ -28,7 +28,7 @@ class Exact(Quantifier):
         self.amount = amount
 
     def build(self):
-        return f"{self.subject}{{self.amount}}"
+        return f"{self.subject}{{{self.amount}}}"
 
 class NOrMore(Quantifier):
     def __init__(self, subject, amount):

--- a/regex_builder/quantifiers.py
+++ b/regex_builder/quantifiers.py
@@ -45,5 +45,5 @@ class Between(Quantifier):
         self.max = max
 
     def build(self):
-        return f"{self.subject}{{{self.min}, {self.max}}}"
+        return f"{self.subject}{{{self.min},{self.max}}}"
 

--- a/regex_builder/section.py
+++ b/regex_builder/section.py
@@ -27,6 +27,6 @@ class Any(Section):
         # parts can be Sections so we string them to call section.build
         parts = "|".join(map(str, self.parts))
         capture = "" if self.capture else "?:"
-        name = f"?<{self.name}>" if self.name else ""
+        name = f"?P<{self.name}>" if self.name else ""
         return f"({capture}{name}{parts})"
 

--- a/tests/test_quantifiers.py
+++ b/tests/test_quantifiers.py
@@ -1,0 +1,10 @@
+import re
+from regex_builder import Regex, Exact, DIGIT
+
+def test_exact():
+    regex = (
+        Regex()
+            .section(Exact(DIGIT, 3))
+    )
+
+    assert regex.build() == r"\d{3}"

--- a/tests/test_quantifiers.py
+++ b/tests/test_quantifiers.py
@@ -1,10 +1,19 @@
 import re
-from regex_builder import Regex, Exact, DIGIT
+from regex_builder import Regex, Exact, Between, DIGIT
 
 def test_exact():
     regex = (
         Regex()
-            .section(Exact(DIGIT, 3))
+        .section(Exact(DIGIT, 3))
     )
 
     assert regex.build() == r"\d{3}"
+
+
+def test_between():
+    regex = (
+        Regex()
+        .section(Between(DIGIT, 1, 5))
+    )
+
+    assert regex.build() == r"\d{1,5}"

--- a/tests/test_quantifiers.py
+++ b/tests/test_quantifiers.py
@@ -1,4 +1,3 @@
-import re
 from regex_builder import Regex, Exact, Between, DIGIT
 
 def test_exact():

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,11 @@
+from regex_builder import Regex, Any, OneOrMore, DIGIT
+
+def test_named_groups():
+    regex = (
+        Regex()
+        .section(Any("A", "B", "C", name="letter"))
+        .section("=")
+        .section(Any(OneOrMore(DIGIT), name="number"))
+    )
+
+    assert regex.match("A=123").groupdict() == {"letter": "A", "number": "123"}


### PR DESCRIPTION
Hi @Zomatree,

I just started using this library in a project and made a few small fixes that I would like to contribute back :)  I also added some tests to cover the changes.

#### 1. Exact quantifier emitting invalid regex

```python
>>> Regex().section(Exact(DIGIT, 3)).build()
'\\d{self.amount}' # Should be '\\d{3}'
```

#### 2. Removed space after comma in `Between` quantifier

Quantifiers are space sensitive:

✅ `\d{1,3}`: Matches 1 to 3 digits
❌ `\d{1, 3}`: Matches a digit followed by `{1, 3}` literal 🤯

#### 3. Fix named capturing groups

Named capturing groups require the [OG Python syntax](https://www.regular-expressions.info/named.html) (`?P=<name>`).